### PR TITLE
fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@reduxjs/toolkit": "^2.6.0",
         "axios": "^1.8.2",
         "clsx": "^2.1.1",
+        "esbuild": "^0.25.0",
         "formik": "^2.4.6",
         "modern-normalize": "^3.0.1",
         "react": "^19.0.0",
@@ -43,7 +44,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -60,7 +60,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -77,7 +76,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -94,7 +92,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -111,7 +108,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -128,7 +124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -145,7 +140,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -162,7 +156,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -179,7 +172,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -196,7 +188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -213,7 +204,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -230,7 +220,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -247,7 +236,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -264,7 +252,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -281,7 +268,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -298,7 +284,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -315,7 +300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -332,7 +316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -349,7 +332,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -366,7 +348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -383,7 +364,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -400,7 +380,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -417,7 +396,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -434,7 +412,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1571,7 +1548,6 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
       "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1615,7 +1591,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@reduxjs/toolkit": "^2.6.0",
     "axios": "^1.8.2",
     "clsx": "^2.1.1",
+    "esbuild": "^0.25.0",
     "formik": "^2.4.6",
     "modern-normalize": "^3.0.1",
     "react": "^19.0.0",


### PR DESCRIPTION
failed to load config from /vercel/path0/vite.config.js error during build:
Error: The package "@esbuild/linux-x64" could not be found, and is needed by esbuild. If you are installing esbuild with npm, make sure that you don't specify the "--no-optional" or "--omit=optional" flags. The "optionalDependencies" feature of "package.json" is used by esbuild to install the correct binary executable for your current platform.
    at generateBinPath (/vercel/path0/node_modules/esbuild/lib/main.js:1754:15)
    at esbuildCommandAndArgs (/vercel/path0/node_modules/esbuild/lib/main.js:1824:33)
    at ensureServiceIsRunning (/vercel/path0/node_modules/esbuild/lib/main.js:1981:25)
    at build (/vercel/path0/node_modules/esbuild/lib/main.js:1880:26)
    at bundleConfigFile (file:///vercel/path0/node_modules/vite/dist/node/chunks/dep-glQox-ep.js:54476:24)
    at async bundleAndLoadConfigFile (file:///vercel/path0/node_modules/vite/dist/node/chunks/dep-glQox-ep.js:54460:19)
    at async loadConfigFromFile (file:///vercel/path0/node_modules/vite/dist/node/chunks/dep-glQox-ep.js:54423:44)
    at async resolveConfig (file:///vercel/path0/node_modules/vite/dist/node/chunks/dep-glQox-ep.js:53931:24)
    at async createBuilder (file:///vercel/path0/node_modules/vite/dist/node/chunks/dep-glQox-ep.js:51936:18)
    at async CAC.<anonymous> (file:///vercel/path0/node_modules/vite/dist/node/cli.js:859:23)
Error: Command "npm run build" exited with 1